### PR TITLE
Issue #41 python version explicit

### DIFF
--- a/pymrio/__init__.py
+++ b/pymrio/__init__.py
@@ -71,3 +71,15 @@ from pymrio.tools.iomath import calc_F_Y
 from pymrio.tools.iomath import calc_M
 from pymrio.tools.iomath import calc_e
 from pymrio.tools.iomath import calc_accounts
+
+
+# #############################################################################
+# Checking python version at run-time
+# #############################################################################
+
+if not (sys.version_info.major == 3 and sys.version_info.minor >= 7):
+    msg = ("Python 3.7 or higher is required\n"
+           + "You are running Python {}.{}".format(sys.version_info.major,
+                                                   sys.version_info.minor))
+    raise Exception(msg)
+    # sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,10 @@ setup(
                       'numpy >= 1.13.4',
                       'xlrd >= 1.1.0'
                      ],
+
+    # Minimum python version
+    python_requires = '>=3.7',
+
     classifiers=[
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
Hi !

Thanks for developing this tool and making it available to all,

I will probably use it in the coming months, and figured I would starts by helping you close some issues.

Since I only discovered MRIO today I don't know yet how it works really and I can't yet contribute to in-depth code parts.
So I looked for what looked like an easy issue to solve,

Main changes:
--------------------
* Python minimum version is now explicit in the setup.py (for install time)
* Python current version is cheecked in the __init__.py (for run time)

Issues:
----------
This PR aims at solving (at least partially) issue #41 


I tried to keep it clean and simple, don't hesitate to let me know if this small contribution suits you

Regards
Didier