### PR TITLE
[Issue #42] OS-dependent path in tools/ioparser.py  

### DIFF
--- a/pymrio/tools/ioparser.py
+++ b/pymrio/tools/ioparser.py
@@ -654,7 +654,7 @@ def parse_exiobase2(path, charact=True, popvector='exio2'):
     if popvector is 'exio2':
         logging.debug('Read population vector')
         io.population = pd.read_csv(os.path.join(PYMRIO_PATH['exio20'],
-                                                 './misc/population.txt'),
+                                                 'misc', 'population.txt'),
                                     index_col=0, sep='\t').astype(float)
     else:
         io.population = popvector


### PR DESCRIPTION
Motivations:
----------------
* As pointed out in issue #42, when @ruairidhcumming tied to load exiobase2, an error message was raised saying that the population.txt file was not found
* @konstantinstadler  suggested that it may have to do with the hard-coded relative path at line 656 of tools/ioparser.py

Main changes:
--------------------
* fixes OS-specific hard-coded relative path in `parse_exiobase2()` for population.txt, as pointed out above 

Issues:
---------
* Fixes only partially the problem brought up by issue #42, by making the relative path OS-independent using os.path.join()
* However, it can be seen that:
    - the problem is solved when pymrio is installed from a github clone
    - the problem is not solved when installed from pypi using pip
The reason for this is that the pip installation does not seem to include the following diretories and data: exio20

Indeed, when checking the content from my github cloned repo:
```
(base) ls /home/didier/Documents/Projects/pymrio/pymrio/mrio_models/
total 16K
drwxrwxr-x 4 didier didier 4,0K oct.  30 15:01 .
drwxrwxr-x 7 didier didier 4,0K oct.  30 16:13 ..
drwxrwxr-x 4 didier didier 4,0K oct.  30 15:01 exio20
-rw-rw-r-- 1 didier didier    0 oct.  30 15:01 __init__.py
drwxrwxr-x 3 didier didier 4,0K oct.  30 15:01 test_mrio
```


When checking from the pip-installed version:
```
(base) ls /home/didier/anaconda3/lib/python3.7/site-packages/pymrio/mrio_models/
total 16K
drwxrwxr-x 4 didier didier 4,0K oct.  30 14:48 .
drwxrwxr-x 6 didier didier 4,0K oct.  30 14:48 ..
-rw-rw-r-- 1 didier didier    0 oct.  30 14:48 __init__.py
drwxrwxr-x 2 didier didier 4,0K oct.  30 14:48 __pycache__
drwxrwxr-x 4 didier didier 4,0K oct.  30 14:48 test_mrio

```
Clearly, exio20 is not included in the pip installation, which means users using pip will have the same issue even after this PR.
Opening a separate issue to deal with this, which should be done both in the setup.py and in a MANIFEST.in from what I know.