### PR TITLE
Issue #50 missing package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+# all files to be included
+
+include MANIFEST.in
+# include LICENSE.txt
+# include pyproject.toml
+recursive-include pymrio/mrio_models/exio20/misc *.txt
+recursive-include pymrio/mrio_models/exio20/concordance *.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@
 include MANIFEST.in
 # include LICENSE.txt
 # include pyproject.toml
-recursive-include pymrio/mrio_models/exio20/misc *.txt
-recursive-include pymrio/mrio_models/exio20/concordance *.txt
+recursive-include pymrio/ *.txt
+recursive-include pymrio/ *.json


### PR DESCRIPTION
Motivation:
---------------
* As explained in issue #50, the pip installation was missing some package data, in particular it was missing the directory `pymrio/mrio_models/exio20`, causing issues #42 and a comment in issue #9 

Main changes:
--------------------
* Added a `MANIFEST.in` files explicitly stating that all .txt and .json files shall be included in the dist
* Added a `__init__.py` file in `pymrio/mrio_models/exio20` to make sure it is properly considered as part of the dist

Test:
-------
* I installed using pip from Pypi and got the same issue as in #42 
* I made the changes in this PR, built a sdist locally and installed from it => issue solved

Issues:
----------
* This PR solves issue #42 and a comment in issue #9 